### PR TITLE
Handle a _handleSwipeMove() Race Condition

### DIFF
--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -130,6 +130,10 @@ class ReactSwipe extends Component {
   }
 
   _handleSwipeMove(event) {
+    if (!this.moveStart) {
+        return;
+    }
+
     const { x, y } = getPosition(event);
     const deltaX = x - this.moveStart.x;
     const deltaY = y - this.moveStart.y;


### PR DESCRIPTION
There is a possible case that `_handleSwipeMove` will begin to execute prior to the completion of `_handleSwipeStart`. When this happens, `this.moveStart` will still be `null` when we attempt to reference its position-based properties.

Since `_handleSwipeMove` is called repeatedly, there should be no danger associated with returning instead of throwing when `moveStart === null`.