### PR TITLE
handleSwipeMove fix pulled off 54302e4

### DIFF
--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -130,6 +130,9 @@ class ReactSwipe extends Component {
   }
 
   _handleSwipeMove(event) {
+    if (!this.moveStart) {
+      return;
+    }
     const { x, y } = getPosition(event);
     const deltaX = x - this.moveStart.x;
     const deltaY = y - this.moveStart.y;


### PR DESCRIPTION
Saw the [PR here](https://github.com/leandrowd/react-easy-swipe/pull/24) that had a fix for a bug I was experiencing. 

This should implement the PR and fix the broken tests.