### PR TITLE
Handle null movePosition

### DIFF
--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -157,7 +157,7 @@ class ReactSwipe extends Component {
 
     const { tolerance } = this.props;
 
-    if (this.moving) {
+    if (this.moving && this.movePosition) {
       if (this.movePosition.deltaX < -tolerance) {
         this.props.onSwipeLeft(1, event);
       } else if (this.movePosition.deltaX > tolerance) {


### PR DESCRIPTION
Currently `_handleSwipeEnd` can occasionally be called while `this.movePosition` is null, resulting in an exception when `this.movePosition.deltaX` is referenced. This small change adds a defensive check to account for that potential race condition.