### PR TITLE
Add ref forwarding, tests for it and some fixes

### DIFF
--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -48,6 +48,7 @@ class ReactSwipe extends Component {
     onSwipeStart: PropTypes.func,
     onSwipeMove: PropTypes.func,
     onSwipeEnd: PropTypes.func,
+    innerRef: PropTypes.func,
     tolerance: PropTypes.number.isRequired
   };
 
@@ -61,6 +62,7 @@ class ReactSwipe extends Component {
     onSwipeStart() {},
     onSwipeMove() {},
     onSwipeEnd() {},
+    innerRef() {},
     tolerance: 0
   };
 
@@ -73,6 +75,8 @@ class ReactSwipe extends Component {
     this._onMouseDown = this._onMouseDown.bind(this);
     this._onMouseMove = this._onMouseMove.bind(this);
     this._onMouseUp = this._onMouseUp.bind(this);
+
+    this._setSwiperRef = this._setSwiperRef.bind(this);
   }
 
   componentDidMount() {
@@ -175,6 +179,11 @@ class ReactSwipe extends Component {
     this.movePosition = null;
   }
 
+  _setSwiperRef(node) {
+    this.swiper = node;
+    this.props.innerRef(node);
+  }
+
   render() {
     const { tagName,
       className,
@@ -193,7 +202,7 @@ class ReactSwipe extends Component {
 
     return (
       <this.props.tagName
-        ref={node => this.swiper = node}
+        ref={ this._setSwiperRef }
         onMouseDown={ this._onMouseDown }
         onTouchStart={ this._handleSwipeStart }
         onTouchEnd={ this._handleSwipeEnd }

--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -7,10 +7,10 @@ export function setHasSupportToCaptureOption(hasSupport) {
 }
 
 try {
-  addEventListener("test", null, Object.defineProperty({}, 'capture', {get: function () {
+  addEventListener('test', null, Object.defineProperty({}, 'capture', { get: function get() {
     setHasSupportToCaptureOption(true);
-  }}));
-} catch(e) {}
+  } }));
+} catch (e) {} // eslint-disable-line no-empty
 
 function getSafeEventHandlerOpts(options = { capture: true }) {
   return supportsCaptureOption ? options : options.capture;

--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -197,6 +197,8 @@ class ReactSwipe extends Component {
       onSwipeStart,
       onSwipeMove,
       onSwipeEnd,
+      innerRef,
+      tolerance,
       ...props
     } = this.props;
 

--- a/test/react-swipe-test.js
+++ b/test/react-swipe-test.js
@@ -3,8 +3,9 @@ import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import chaiSinon from 'chai-sinon';
 import ReactSwipe, { setHasSupportToCaptureOption } from '../src/react-swipe';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
+import jsdom from 'jsdom';
 
 chai.use(chaiEnzyme());
 chai.use(chaiSinon);
@@ -296,8 +297,7 @@ describe('react-swipe', () => {
             });
           });
         });
-      })
-
+      });
 
       it('should reset moveStart, moving and movePosition', () => {
         instance._handleSwipeEnd(event);
@@ -380,6 +380,29 @@ describe('react-swipe', () => {
           instance._onMouseUp(event);
           expect(instance._handleSwipeEnd).to.have.been.calledWith(event);
         });
+      });
+    });
+
+    context('passing ref', () => {
+      let node;
+
+      function forwardedRef(ref) {
+        node = ref;
+      }
+
+      const doc = jsdom.jsdom('<!doctype html><html><body></body></html>');
+      global.document = doc;
+      global.window = doc.defaultView;
+
+      const mounted = mount(<ReactSwipe innerRef={forwardedRef} />);
+      const mountedInstance = mounted.instance();
+
+      it('should pass innerRef prop', () => {
+        expect(mounted).to.have.prop('innerRef', forwardedRef);
+      });
+
+      it('should forwards ref', () => {
+        expect(node).to.be.equal(mountedInstance.swiper);
       });
     });
   });

--- a/test/react-swipe-test.js
+++ b/test/react-swipe-test.js
@@ -248,7 +248,7 @@ describe('react-swipe', () => {
             });
 
             it(`should call onSwipeRight if deltaX is greater than the tolerance of ${tolerance}`, () => {
-              instance.movePosition.deltaX =  (tolerance + 1);
+              instance.movePosition.deltaX = (tolerance + 1);
               instance._handleSwipeEnd(event);
 
               expect(onSwipeRight).to.have.been.calledWith(1, event);
@@ -262,7 +262,7 @@ describe('react-swipe', () => {
             });
 
             it(`should call onSwipeDown if deltaY is greater than the tolerance of ${tolerance}`, () => {
-              instance.movePosition.deltaY =  (tolerance + 1);
+              instance.movePosition.deltaY = (tolerance + 1);
               instance._handleSwipeEnd(event);
 
               expect(onSwipeDown).to.have.been.calledWith(1, event);


### PR DESCRIPTION
- Added ref forwarding inside `react-easy-swipe` instance through `innerRef` prop. Used a class method for assigning ref: it makes render cheaper too.

- Added tests for ref forwarding

- Removed `innerRef` and `tolerance` props from passing down to DOM-node in render method

- Fixed eslint errors and warnings