### PR TITLE
Prevent errors thrown on non-cancelable events

### DIFF
--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -149,7 +149,7 @@ class ReactSwipe extends Component {
       y: deltaY
     }, event);
 
-    if (shouldPreventDefault) {
+    if (shouldPreventDefault && event.cancelable) {
       event.preventDefault();
     }
 

--- a/test/react-swipe-test.js
+++ b/test/react-swipe-test.js
@@ -128,7 +128,8 @@ describe('react-swipe', () => {
         touches: [{
           pageX: 123,
           pageY: 321
-        }]
+        }],
+        cancelable: true
       };
 
       beforeEach(() => {
@@ -157,18 +158,33 @@ describe('react-swipe', () => {
         }, event);
       });
 
-      it('should call prevent default if the result of onSwipeMove is true', () => {
+      it('should call prevent default, if the result of onSwipeMove and event.cancelable is true', () => {
         const preventDefault = sandbox.spy();
-
+        
         instance._handleSwipeMove({ ...event, preventDefault });
 
         expect(preventDefault).to.have.callCount(0);
 
         onSwipeMove.returns(true);
 
+        expect(event.cancelable).to.be.true;
+        instance._handleSwipeMove({ ...event, preventDefault });
+        expect(preventDefault).to.have.callCount(1);
+      });
+
+      it('should *not* call prevent default, if the result of onSwipeMove and event.cancelable is false', () => {
+        const preventDefault = sandbox.spy();
+        event.cancelable = false;
+        
         instance._handleSwipeMove({ ...event, preventDefault });
 
-        expect(preventDefault).to.have.callCount(1);
+        expect(preventDefault).to.have.callCount(0);
+
+        onSwipeMove.returns(false);
+
+        expect(event.cancelable).to.be.false;
+        instance._handleSwipeMove({ ...event, preventDefault });
+        expect(preventDefault).to.have.callCount(0);
       });
 
       it('should store the current position', () => {


### PR DESCRIPTION
There are issues being reported in: [`react-responsive-carousel`](https://github.com/leandrowd/react-responsive-carousel/issues/358) 
where the carousel is scrolling on vertical scrolls, and it throws an uncaught error: 
`react-swipe.js:226 [Intervention] Ignored attempt to cancel a touch move event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.`

I added a check for the cancelable attribute on events in the `_handleSwipeMove` function to prevent this, and updated tests covering it.