### PR TITLE
Make `innerRef` optional in ts types

### DIFF
--- a/react-easy-swipe.d.ts
+++ b/react-easy-swipe.d.ts
@@ -20,7 +20,7 @@ interface SwipeProps {
   onSwipeStart?: (e: SwipeEvent) => void;
   onSwipeMove?: (position: SwipePosition, e: SwipeEvent) => void;
   onSwipeEnd?: (e: SwipeEvent) => void;
-  innerRef: (node: any) => void;
+  innerRef?: (node: any) => void;
   tolerance?: number
 }
 


### PR DESCRIPTION
As I see `innerRef` isn't required property.