### PR TITLE
Swipe component should accept valid React children

### DIFF
--- a/react-easy-swipe.d.ts
+++ b/react-easy-swipe.d.ts
@@ -24,4 +24,4 @@ interface SwipeProps {
   tolerance?: number
 }
 
-export default class Swipe extends React.Component<SwipeProps> {}
+export default class Swipe extends React.Component<React.PropsWithChildren<SwipeProps>> {}


### PR DESCRIPTION
A simple Typescript for Swipe component
As far as I can see, it should be able to accept any valid React Children

Repro case [HERE](https://stackblitz.com/edit/react-ts-rlp8eu?file=App.tsx)

