### PR TITLE
Support react 18

### DIFF
--- a/react-easy-swipe.d.ts
+++ b/react-easy-swipe.d.ts
@@ -21,7 +21,8 @@ interface SwipeProps {
   onSwipeMove?: (position: SwipePosition, e: SwipeEvent) => void;
   onSwipeEnd?: (e: SwipeEvent) => void;
   innerRef?: (node: any) => void;
-  tolerance?: number
+  tolerance?: number;
+  children?: React.ReactNode
 }
 
 export default class Swipe extends React.Component<SwipeProps> {}


### PR DESCRIPTION
There is no children in React.Component in React 18. Need to define children manually in the SwipeProps https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc