### PR TITLE
Supoort custom touch event options

### DIFF
--- a/react-easy-swipe.d.ts
+++ b/react-easy-swipe.d.ts
@@ -23,6 +23,7 @@ interface SwipeProps {
   innerRef?: (node: any) => void;
   tolerance?: number;
   children?: React.ReactNode
+  eventOptions?: AddEventListenerOptions | boolean;
 }
 
 export default class Swipe extends React.Component<SwipeProps> {}

--- a/src/react-swipe.js
+++ b/src/react-swipe.js
@@ -49,7 +49,11 @@ class ReactSwipe extends Component {
     onSwipeMove: PropTypes.func,
     onSwipeEnd: PropTypes.func,
     innerRef: PropTypes.func,
-    tolerance: PropTypes.number.isRequired
+    tolerance: PropTypes.number.isRequired,
+    eventOptions: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.bool
+    ])
   };
 
   static defaultProps = {
@@ -63,7 +67,8 @@ class ReactSwipe extends Component {
     onSwipeMove() {},
     onSwipeEnd() {},
     innerRef() {},
-    tolerance: 0
+    tolerance: 0,
+    eventOptions: { capture: true, passive: false }
   };
 
   constructor(...args) {
@@ -81,19 +86,13 @@ class ReactSwipe extends Component {
 
   componentDidMount() {
     if (this.swiper) {
-      this.swiper.addEventListener('touchmove', this._handleSwipeMove, getSafeEventHandlerOpts({
-        capture: true,
-        passive: false
-      }));
+      this.swiper.addEventListener('touchmove', this._handleSwipeMove, getSafeEventHandlerOpts(this.props.eventOptions));
     }
   }
 
   componentWillUnmount() {
     if (this.swiper) {
-      this.swiper.removeEventListener('touchmove', this._handleSwipeMove, getSafeEventHandlerOpts({
-        capture: true,
-        passive: false
-      }));
+      this.swiper.removeEventListener('touchmove', this._handleSwipeMove, getSafeEventHandlerOpts(this.props.eventOptions));
     }
   }
 


### PR DESCRIPTION
Because the touch event option is fixed to capture, occasionally the event handler is firing in an unwanted order while using the event.
It would be great if event options could be customized as ReactProps so that the user can fire the event handler as desired